### PR TITLE
fix empty  Mvid

### DIFF
--- a/src/DistIL/AsmIO/ModuleWriter.cs
+++ b/src/DistIL/AsmIO/ModuleWriter.cs
@@ -31,7 +31,7 @@ internal partial class ModuleWriter
         var mainModHandle = _builder.AddModule(
             0, 
             AddString(_mod.ModName), 
-            _builder.GetOrAddGuid(default),
+            _builder.GetOrAddGuid(Guid.NewGuid()),
             _builder.GetOrAddGuid(default),
             _builder.GetOrAddGuid(default)
         );


### PR DESCRIPTION
If Mvid is empty the assembly cannot be run on wasm with mono.

I tested the fix running on dotnet and wasm